### PR TITLE
Handle zero gain/loss RSI windows explicitly

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,92 @@
+"""RSI computation utilities."""
+from __future__ import annotations
+
+from math import isclose, nan
+from typing import Iterable, List
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd
+except ModuleNotFoundError:  # pragma: no cover - executed when pandas missing
+    pd = None  # type: ignore[assignment]
+
+
+def _resolve_rsi_value(avg_gain: float, avg_loss: float) -> float:
+    """Return the RSI value for the supplied average gain/loss pair."""
+
+    if isclose(avg_gain, 0.0) and isclose(avg_loss, 0.0):
+        return 50.0
+    if isclose(avg_loss, 0.0):
+        return 100.0
+    if isclose(avg_gain, 0.0):
+        return 0.0
+
+    relative_strength = avg_gain / avg_loss
+    return 100.0 - (100.0 / (1.0 + relative_strength))
+
+
+def _wrap_result(values: List[float], original: Iterable[float]):
+    """Wrap a result list into a Series when pandas is available."""
+
+    if pd is None:
+        return values
+
+    if isinstance(original, pd.Series):
+        return pd.Series(values, index=original.index, dtype="float64")
+
+    return pd.Series(values, dtype="float64")
+
+
+def _compute_rsi(prices: Iterable[float], lookback: int = 14):
+    """Compute the Relative Strength Index for a price sequence.
+
+    Parameters
+    ----------
+    prices
+        Iterable of price values ordered chronologically.
+    lookback
+        Number of periods used for the Wilder exponential moving average.
+
+    Returns
+    -------
+    Sequence of floats (or ``pandas.Series`` when pandas is installed)
+        RSI values with the same length as the input sequence. Entries before a
+        full lookback window are ``NaN``.
+    """
+
+    if lookback <= 0:
+        raise ValueError("lookback must be a positive integer")
+
+    prices_list = [float(price) for price in prices]
+    count = len(prices_list)
+
+    if count == 0:
+        return _wrap_result([], prices)
+
+    rsi_values: List[float] = [nan] * count
+
+    if count <= lookback:
+        return _wrap_result(rsi_values, prices)
+
+    gains = [0.0] * count
+    losses = [0.0] * count
+
+    for idx in range(1, count):
+        change = prices_list[idx] - prices_list[idx - 1]
+        if change > 0:
+            gains[idx] = change
+        else:
+            losses[idx] = -change
+
+    avg_gain = sum(gains[1 : lookback + 1]) / lookback
+    avg_loss = sum(losses[1 : lookback + 1]) / lookback
+    rsi_values[lookback] = _resolve_rsi_value(avg_gain, avg_loss)
+
+    for idx in range(lookback + 1, count):
+        avg_gain = ((avg_gain * (lookback - 1)) + gains[idx]) / lookback
+        avg_loss = ((avg_loss * (lookback - 1)) + losses[idx]) / lookback
+        rsi_values[idx] = _resolve_rsi_value(avg_gain, avg_loss)
+
+    return _wrap_result(rsi_values, prices)
+
+
+__all__ = ["_compute_rsi"]

--- a/scripts/manual_verify.py
+++ b/scripts/manual_verify.py
@@ -1,0 +1,33 @@
+from pprint import pprint
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import _compute_rsi
+
+
+CASES = {
+    "all_gains": {
+        "prices": [1, 2, 3, 4, 5, 6],
+        "lookback": 3,
+    },
+    "all_losses": {
+        "prices": [6, 5, 4, 3, 2, 1],
+        "lookback": 3,
+    },
+    "flat": {
+        "prices": [4, 4, 4, 4, 4, 4],
+        "lookback": 3,
+    },
+    "mixed_short": {
+        "prices": [10, 11, 12, 11, 12, 10, 13],
+        "lookback": 2,
+    },
+}
+
+
+for name, params in CASES.items():
+    print(f"\n{name}")
+    result = _compute_rsi(params["prices"], params["lookback"])
+    pprint(list(result))

--- a/tests/test_rsi.py
+++ b/tests/test_rsi.py
@@ -1,0 +1,50 @@
+from math import isclose
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import _compute_rsi
+
+
+def assert_sequence_close(result, expected):
+    assert len(result) == len(expected)
+    for actual, target in zip(result, expected):
+        if target != target:  # NaN check
+            assert actual != actual
+        else:
+            assert isclose(actual, target, rel_tol=1e-9, abs_tol=1e-9)
+
+
+def test_insufficient_history_returns_nan():
+    prices = [100, 101, 102]
+    rsi = _compute_rsi(prices, lookback=5)
+    assert all(value != value for value in rsi)
+
+
+def test_all_gains_returns_hundred_after_window():
+    prices = [1, 2, 3, 4, 5]
+    rsi = _compute_rsi(prices, lookback=2)
+    expected = [float("nan"), float("nan"), 100.0, 100.0, 100.0]
+    assert_sequence_close(rsi, expected)
+
+
+def test_all_losses_returns_zero_after_window():
+    prices = [5, 4, 3, 2, 1]
+    rsi = _compute_rsi(prices, lookback=2)
+    expected = [float("nan"), float("nan"), 0.0, 0.0, 0.0]
+    assert_sequence_close(rsi, expected)
+
+
+def test_flat_series_returns_fifty_after_window():
+    prices = [5, 5, 5, 5, 5]
+    rsi = _compute_rsi(prices, lookback=2)
+    expected = [float("nan"), float("nan"), 50.0, 50.0, 50.0]
+    assert_sequence_close(rsi, expected)
+
+
+def test_short_series_returns_expected_values():
+    prices = [10, 11, 12, 11, 12]
+    rsi = _compute_rsi(prices, lookback=2)
+    expected = [float("nan"), float("nan"), 100.0, 50.0, 75.0]
+    assert_sequence_close(rsi, expected)


### PR DESCRIPTION
## Summary
- replace the RSI calculation with an implementation that explicitly maps zero-loss, zero-gain, and flat windows to 100/0/50 while leaving insufficient history as NaN
- support optional pandas output while keeping the core computation dependency-free
- add regression tests and a manual verification script that exercise synthetic price series to validate the expected RSI outcomes

## Testing
- pytest
- python scripts/manual_verify.py

------
https://chatgpt.com/codex/tasks/task_e_68dca74d23e8832d8136e428bd13dbe1